### PR TITLE
[Feat / Block] 채팅 서버 라우팅 하기 - Block #38

### DIFF
--- a/src/gateway/chatserver/block/block.controller.spec.ts
+++ b/src/gateway/chatserver/block/block.controller.spec.ts
@@ -1,0 +1,121 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from 'src/app.module';
+import { TestService } from 'src/test/test.service';
+import { DataSource } from 'typeorm';
+import {
+  addTransactionalDataSource,
+  initializeTransactionalContext,
+} from 'typeorm-transactional';
+
+describe('GatewayFriendRelationController', () => {
+  let app: INestApplication;
+  let testService: TestService;
+  let dataSources: DataSource;
+
+  initializeTransactionalContext();
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+    testService = moduleFixture.get<TestService>(TestService);
+    dataSources = moduleFixture.get<DataSource>(DataSource);
+    await dataSources.synchronize(true);
+  });
+  beforeEach(async () => {
+    await testService.createProfileImages();
+  });
+  afterAll(async () => {
+    await dataSources.dropDatabase();
+    await dataSources.destroy();
+    // await app.close();
+  });
+
+  afterEach(async () => {
+    testService.clear();
+    jest.resetAllMocks();
+    await dataSources.synchronize(true);
+  });
+
+  describe('ROUTE FRIENDS TEST', () => {
+    describe('GET /users/blocks/', () => {
+      it('[Error Case] jwt 가드 에 막혔을때', async () => {
+        const user = await testService.createBasicUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .get('/users/blocks/')
+          .set({
+            Authorization: `no Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(401);
+      });
+      it('[Valid Case] 성공', async () => {
+        const user = await testService.createBasicUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .get('/users/blocks/')
+          .set({
+            Authorization: `Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(200);
+      });
+    });
+
+    describe('POST /users/blocks/:nickname', () => {
+      it('[Error Case] jwt 가드 에 막혔을때', async () => {
+        const user = await testService.createBasicUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .post(`/users/blocks/${user.nickname}`)
+          .set({
+            Authorization: `no Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(401);
+      });
+      it('[Valid Case] 성공', async () => {
+        const user = await testService.createBasicUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .post(`/users/blocks/${user.nickname}`)
+          .set({
+            Authorization: `Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(201);
+      });
+    });
+
+    describe('DELETE /users/blocks/:nickname', () => {
+      it('[Error Case] jwt 가드 에 막혔을때', async () => {
+        const user = await testService.createBasicUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .delete(`/users/blocks/${user.nickname}`)
+          .set({
+            Authorization: `no Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(401);
+      });
+      it('[Valid Case] 성공', async () => {
+        const user = await testService.createBasicUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .delete(`/users/blocks/${user.nickname}`)
+          .set({
+            Authorization: `Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(200);
+      });
+    });
+  });
+});

--- a/src/gateway/chatserver/block/block.controller.ts
+++ b/src/gateway/chatserver/block/block.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Logger,
+  UseGuards,
+  Req,
+  Post,
+  Delete,
+} from '@nestjs/common';
+import axios from 'axios';
+import { AuthGuard } from '@nestjs/passport';
+import { BlocksUserResponseDto } from '../dtos/user-blocks-response.dto';
+
+@Controller('/users/blocks')
+export class GatewayBlockController {
+  private readonly logger: Logger = new Logger(GatewayBlockController.name);
+
+  @Get('/')
+  @UseGuards(AuthGuard('jwt'))
+  async userBlocksGet(@Req() request): Promise<BlocksUserResponseDto> {
+    try {
+      const accessToken = request.headers.authorization;
+      const response = await axios.get(
+        process.env.CHATSERVER_URL + `/users/blocks`,
+        {
+          headers: { Authorization: accessToken },
+        },
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  @Post('/:nickname')
+  @UseGuards(AuthGuard('jwt'))
+  async userBlocksPost(
+    @Req() request,
+    @Param('nickname') nickname: string,
+  ): Promise<void> {
+    try {
+      const accessToken = request.headers.authorization;
+      const response = await axios.post(
+        process.env.CHATSERVER_URL + `/users/blocks/${nickname}`,
+        {
+          headers: { Authorization: accessToken },
+        },
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  @Delete('/:nickname')
+  @UseGuards(AuthGuard('jwt'))
+  async userBlocksDelete(
+    @Req() request,
+    @Param('nickname') nickname: string,
+  ): Promise<void> {
+    try {
+      const accessToken = request.headers.authorization;
+      const response = await axios.delete(
+        process.env.CHATSERVER_URL + `/users/blocks/${nickname}`,
+        {
+          headers: { Authorization: accessToken },
+        },
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+}

--- a/src/gateway/chatserver/dtos/user-blocks-response.dto.ts
+++ b/src/gateway/chatserver/dtos/user-blocks-response.dto.ts
@@ -1,0 +1,3 @@
+export class BlocksUserResponseDto {
+  users: { nickname: string; imgUrl: string }[];
+}

--- a/src/gateway/gateway.module.ts
+++ b/src/gateway/gateway.module.ts
@@ -5,6 +5,7 @@ import { GatewayUserStatRankController } from './webserver/gateway-user-stat-ran
 import { GatewayRankController } from './webserver/gateway-rank-controller';
 import { GatewayUserRecordsController } from './webserver/gateway-user-records-controller';
 import { GatewayFriendRelationController } from './chatserver/friends/friend-relation.controller';
+import { GatewayBlockController } from './chatserver/block/block.controller';
 @Module({
   controllers: [
     // webserver
@@ -15,6 +16,7 @@ import { GatewayFriendRelationController } from './chatserver/friends/friend-rel
     GatewayRankController,
     // chatserver
     GatewayFriendRelationController,
+    GatewayBlockController,
   ],
 })
 export class GatewayModule {}


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#38 
+ PR Type: `feat`,  `question`

## Summary
<!-- 해당 기능에 대한 요약글 -->
채팅 서버 라우팅 하기 - Block 
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- GET '/users/blocks/'
- POST '/users/blocks/:nickname'
- DELETE '/users/blocks/:nickname'
## Etc
Q. 
- API-Gateway 서버 디비에 user {id : 1 , nickname: user0 } 이 존재하고  만약에 chat 서버 디비엔 아무유저도 없을때 첫번째 GET 요청이 성공 한다.
- 왜냐면 Block리스트 가져오는거 안에 repository 안의 find하는 부분에서 존재하지 않는 유저를 찾아도 빈배열이 반환 되고 실제로 없는 유저를 찾아도 빈배열을 반환해서 똑같이 200 OK가 뜬다 
- 이걸 어떻게 생각하시나요?   

