### PR TITLE
[Feat / User] 각 서버한테 저장한 유저 저장하라고 쏴주기 #31

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -33,7 +33,5 @@ export class AuthController {
       nickname: body.nickname,
       imageId: body.imgId,
     });
-    // 각 서버별로 쏴주는거 requestor 객체 자체
-    this.authService.requestStoreUserInfoEachServers(requestor); // 여기에 await 를 붙여야하나?
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Logger, Post, Req } from '@nestjs/common';
+import { Body, Controller, Logger, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthDto } from './dto/auth.dto';
 import { SignUpRequestDto } from './dto/auth.signup.request.dto';
 import { JwtDto } from './jwt/jwt.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { Requestor } from './jwt/auth.requestor.decorator';
 
 @Controller('auth')
 export class AuthController {
@@ -20,12 +22,18 @@ export class AuthController {
   }
 
   @Post('signup')
-  async signUp(@Body() body: SignUpRequestDto, @Req() req) {
-    const userId: number = req.user.id;
+  @UseGuards(AuthGuard('jwt')) // -> 노네임일때 통과하는 가드 하나 만들어야함 (jwt-noname)
+  async signUp(
+    @Body() body: SignUpRequestDto,
+    @Requestor() requestor: AuthDto,
+  ) {
+    const userId: number = requestor.id;
     await this.authService.signUp({
       userId,
       nickname: body.nickname,
       imageId: body.imgId,
     });
+    // 각 서버별로 쏴주는거 requestor 객체 자체
+    this.authService.requestStoreUserInfoEachServers(requestor); // 여기에 await 를 붙여야하나?
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -93,7 +93,7 @@ export class AuthService {
       profileImage,
       nickname: signUpDto.nickname,
     });
-    this.requestStoreUserInfoEachServers(uploadUser); // 여기에 await 를 붙여야하나?
+    await this.requestStoreUserInfoEachServers(uploadUser);
   }
 
   async getFTAccessToken(authCode: string): Promise<string> {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -191,6 +191,6 @@ export class AuthService {
   }
 
   async axiosRequestStoreServer(serverLocation: string, user: postUserDto) {
-    await axios.post(serverLocation + '/store/user', user);
+    await axios.post(serverLocation + '/users', user);
   }
 }

--- a/src/auth/dto/post.user.dto.ts
+++ b/src/auth/dto/post.user.dto.ts
@@ -1,0 +1,15 @@
+export class postUserDto {
+  id: number;
+
+  nickname: string;
+
+  imgId: number;
+
+  imgUrl: string;
+  constructor(id: number, nickname: string, imgId: number, imgUrl: string) {
+    this.id = id;
+    this.nickname = nickname;
+    this.imgId = imgId;
+    this.imgUrl = imgUrl;
+  }
+}


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#31 
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 각 서버한테 저장한 유저 저장하라고 쏴주기
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 노네임인 유서가 singup 해서 멤버 타입 받고 저장 되면 그때 각 서버한테 postUserDto에 맞게 쏴준다. {id, nickname, imgId, imgUrl}
## Etc
- 로그인 로직 이 바뀐 부분이 있는데 이거 머지 하고 따로 브랜치 파서 할예정입니다.