### PR TITLE
[Fix] Axios 사용법 에러 수정 #49

### DIFF
--- a/src/gateway/chatserver/channels/admin.controller.ts
+++ b/src/gateway/chatserver/channels/admin.controller.ts
@@ -28,7 +28,6 @@ export class GatewayChannelAdminController {
   ): Promise<void> {
     try {
       const accessToken: string = request.headers.authorization;
-      console.log(accessToken);
       const response = await axios.patch(
         process.env.CHATSERVER_URL + `/channels/${channelId}`,
         requestDto,

--- a/src/gateway/chatserver/friends/friend-chat.controller.ts
+++ b/src/gateway/chatserver/friends/friend-chat.controller.ts
@@ -58,9 +58,9 @@ export class GatewayFriendChatController {
       const accessToken = request.headers.authorization;
       const response = await axios.post(
         process.env.CHATSERVER_URL + `/users/friends/:${nickname}/chats`,
+        { message: postFriendChatRequestDto.message },
         {
           headers: { Authorization: accessToken },
-          data: { message: postFriendChatRequestDto.message },
         },
       );
       return response.data;

--- a/src/gateway/chatserver/friends/friend-relation.controller.ts
+++ b/src/gateway/chatserver/friends/friend-relation.controller.ts
@@ -46,6 +46,7 @@ export class GatewayFriendRelationController {
       const accessToken = request.headers.authorization;
       const response = await axios.post(
         process.env.CHATSERVER_URL + `/users/friends/pendings/${nickname}`,
+        {},
         {
           headers: { Authorization: accessToken },
         },
@@ -85,6 +86,7 @@ export class GatewayFriendRelationController {
       const accessToken = request.headers.authorization;
       const response = await axios.post(
         process.env.CHATSERVER_URL + `/users/friends/${nickname}}`,
+        {},
         {
           headers: { Authorization: accessToken },
         },

--- a/src/gateway/webserver/gateway-user-collectables.controller.ts
+++ b/src/gateway/webserver/gateway-user-collectables.controller.ts
@@ -9,6 +9,7 @@ import {
   ParseBoolPipe,
   Logger,
   UseGuards,
+  Req,
 } from '@nestjs/common';
 import axios from 'axios';
 import { UserAchievementsResponseDto } from './dtos/user-achievements-response.dto';
@@ -38,8 +39,8 @@ export class GatewayUserCollectablesController {
   ): Promise<UserAchievementsResponseDto> {
     try {
       const response = await axios.get(
-        process.env.WEBSERVER_URI + `/users/${nickname}/achievements`,
-        { params: { selected } },
+        process.env.WEBSERVER_URI +
+          `/users/${nickname}/achievements?selected=${selected}`,
       );
       return response.data;
     } catch (error) {
@@ -55,8 +56,8 @@ export class GatewayUserCollectablesController {
   ): Promise<UserEmojisResponseDto> {
     try {
       const response = await axios.get(
-        process.env.WEBSERVER_URI + `/users/${nickname}/emojis`,
-        { params: { selected } },
+        process.env.WEBSERVER_URI +
+          `/users/${nickname}/emojis?selected=${selected}`,
       );
       return response.data;
     } catch (error) {
@@ -96,12 +97,15 @@ export class GatewayUserCollectablesController {
   async usersDetailByNicknamePatch(
     @Param('nickname') nickname: string,
     @Body() PatchRequestDto: PatchUserTitleRequestDto,
+    @Req() request,
   ): Promise<void> {
     try {
+      const accessToken = request.headers.authorization;
       await axios.patch(
         process.env.WEBSERVER_URI + `/users/${nickname}/title`,
+        { id: PatchRequestDto.id },
         {
-          data: { id: PatchRequestDto.id },
+          headers: { Authorization: accessToken },
         },
       );
     } catch (error) {
@@ -114,11 +118,17 @@ export class GatewayUserCollectablesController {
   async usersImageByNicknamePatch(
     @Param('nickname') nickname: string,
     @Body() PatchRequestDto: PatchUserImageRequestDto,
+    @Req() request,
   ): Promise<void> {
     try {
-      await axios.patch(process.env.WEBSERVER_URI + `/${nickname}/image`, {
-        data: { id: PatchRequestDto.id },
-      });
+      const accessToken = request.headers.authorization;
+      await axios.patch(
+        process.env.WEBSERVER_URI + `/${nickname}/image`,
+        { id: PatchRequestDto.id },
+        {
+          headers: { Authorization: accessToken },
+        },
+      );
     } catch (error) {
       throw error.response.data;
     }
@@ -129,11 +139,18 @@ export class GatewayUserCollectablesController {
   async usersMessageByNicknamePatch(
     @Param('nickname') nickname: string,
     @Body() PatchRequestDto: PatchUserMessageRequestDto,
+    @Req() request,
   ): Promise<void> {
     try {
-      await axios.patch(process.env.WEBSERVER_URI + `/${nickname}/message`, {
-        data: { message: PatchRequestDto.message },
-      });
+      const accessToken = request.headers.authorization;
+
+      await axios.patch(
+        process.env.WEBSERVER_URI + `/${nickname}/message`,
+        { message: PatchRequestDto.message },
+        {
+          headers: { Authorization: accessToken },
+        },
+      );
     } catch (error) {
       throw error.response.data;
     }
@@ -144,12 +161,14 @@ export class GatewayUserCollectablesController {
   async userAchievementsByNicknamePatch(
     @Param('nickname') nickname: string,
     @Body() PatchRequestDto: PatchUserAchievementsRequestDto,
+    @Req() request,
   ): Promise<void> {
     try {
       await axios.patch(
         process.env.WEBSERVER_URI + `/${nickname}/achievements`,
+        { ids: PatchRequestDto.ids },
         {
-          data: { ids: PatchRequestDto.ids },
+          headers: { Authorization: request.headers.authorization },
         },
       );
     } catch (error) {
@@ -162,11 +181,16 @@ export class GatewayUserCollectablesController {
   async userEmojisByNicknamePatch(
     @Param('nickname') nickname: string,
     @Body() PatchRequestDto: PatchUserEmojisRequestDto,
+    @Req() request,
   ): Promise<void> {
     try {
-      await axios.patch(process.env.WEBSERVER_URI + `/${nickname}/emojis`, {
-        data: { ids: PatchRequestDto.ids },
-      });
+      await axios.patch(
+        process.env.WEBSERVER_URI + `/${nickname}/emojis`,
+        { ids: PatchRequestDto.ids },
+        {
+          headers: { Authorization: request.headers.authorization },
+        },
+      );
     } catch (error) {
       throw error.response.data;
     }


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#49
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- axios 사용 할때 잘못 사용하고 있었습니다.
## Detail
<!-- 해당 기능에 대한 상세 요소-->
```
@Patch('/:roomId')
  @UseGuards(AuthGuard('jwt'))
  async channelPatch(
    @Req() request,
    @Param('roomId') channelId: string,
    @Body() requestDto: ChannelPatchRequestDto,
  ): Promise<void> {
    try {
      const accessToken: string = request.headers.authorization;
      console.log(accessToken);
      const response = await axios.patch(
        process.env.CHATSERVER_URL + `/channels/${channelId}`,
        requestDto,
        {
          headers: {
            Authorization: accessToken,
          },
        },
      );
      return response.data;
    } catch (error) {
      throw error.response.data;
    }
  }
  ```
- 이렇게 body부분은 따로 빼고 
-  헤더 부분도 객체로 또 따로 빼서 보내야 합니다

