### PR TITLE
[Feat] 타입이 노네임이여도 통과하는 가드 데코레이터 하나 구현 #59

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from 'src/app.module';
+import { TestService } from 'src/test/test.service';
+import { DataSource } from 'typeorm';
+import {
+  addTransactionalDataSource,
+  initializeTransactionalContext,
+} from 'typeorm-transactional';
+
+describe('AuthController', () => {
+  let app: INestApplication;
+  let testService: TestService;
+  let dataSources: DataSource;
+
+  initializeTransactionalContext();
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+    testService = moduleFixture.get<TestService>(TestService);
+    dataSources = moduleFixture.get<DataSource>(DataSource);
+    await dataSources.synchronize(true);
+  });
+  beforeEach(async () => {
+    await testService.createProfileImages();
+  });
+  afterAll(async () => {
+    await dataSources.dropDatabase();
+    await dataSources.destroy();
+    // await app.close();
+  });
+
+  afterEach(async () => {
+    testService.clear();
+    jest.resetAllMocks();
+    await dataSources.synchronize(true);
+  });
+
+  describe('AUTH CONTROLLER TEST', () => {
+    describe('POST /auth/singup', () => {
+      it('[Error Case] jwt 가드 에 막혔을때 : 닉네임이 있을때', async () => {
+        const user = await testService.createBasicUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .post(`/auth/signup`)
+          .send({ nickname: 'test', imgId: 1 })
+          .set({
+            Authorization: `Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(400);
+      });
+      it('[Valid Case] 요청 성공했을때 : 닉네임이 null 이고 토큰 통과', async () => {
+        const user = await testService.createNonameUser();
+        const token = await testService.giveTokenToUser(user);
+        const response = await request(app.getHttpServer())
+          .post(`/auth/signup`)
+          .send({ nickname: 'private', imgId: 1 })
+          .set({
+            Authorization: `Bearer ${token}`,
+            withCredentials: true,
+          });
+        expect(response.statusCode).toBe(201);
+      });
+    });
+  });
+});

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,10 +9,11 @@ import { UserRepository } from '../user/user.repository';
 import { ProfileImageRepository } from './profile-image.repository';
 import { User } from '../user/user.entity';
 import { ProfileImage } from './profile-image.entity';
+import { JwtStrategyNoname } from './jwt/noname.jwt.strategy';
 
 @Module({
   imports: [
-    PassportModule.register({ defaultStrategy: 'jwt' }),
+    PassportModule.register({ Strategy: ['jwt', 'jwtNoname'] }),
     JwtModule.register({
       secret: 'jwtSecret',
       signOptions: {
@@ -22,7 +23,13 @@ import { ProfileImage } from './profile-image.entity';
     TypeOrmModule.forFeature([User, ProfileImage]),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, UserRepository, ProfileImageRepository],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    JwtStrategyNoname,
+    UserRepository,
+    ProfileImageRepository,
+  ],
   exports: [JwtModule, JwtStrategy, PassportModule, AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -86,6 +86,7 @@ export class AuthService {
       user,
       profileImage,
       nickname: signUpDto.nickname,
+      secondAuthRequierd: false,
     });
     const uploadUser = new postUserDto(
       signUser.id,
@@ -137,7 +138,7 @@ export class AuthService {
     const token = this.jwtService.sign({
       id: user.id,
       nickname: user.nickname,
-      secondAuthRequired: user.secondAuthRequired,
+      secondAuthRequired: user.secondAuthRequired ?? false,
       roleType: user.roleType,
     });
     return token;

--- a/src/auth/dto/update.user.signup.dto.ts
+++ b/src/auth/dto/update.user.signup.dto.ts
@@ -5,4 +5,5 @@ export class UpdateUserSignUpDto {
   user: User;
   profileImage: ProfileImage;
   nickname: string;
+  secondAuthRequierd: boolean;
 }

--- a/src/auth/jwt/noname.jwt.strategy.ts
+++ b/src/auth/jwt/noname.jwt.strategy.ts
@@ -1,0 +1,36 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { AuthDto } from '../dto/auth.dto';
+import { TokenInterface } from './jwt.token.interface';
+import { UserRepository } from '../../user/user.repository';
+import { ROLETYPE_NONAME } from '../../user/type.user.roletype';
+
+@Injectable()
+export class JwtStrategyNoname extends PassportStrategy(Strategy, 'jwtNoname') {
+  constructor(private readonly userRepository: UserRepository) {
+    super({
+      secretOrKey: 'jwtSecret',
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+    });
+  }
+  users: Map<string, AuthDto> = new Map();
+
+  async validate(payload): Promise<AuthDto> {
+    const user = await this.findUser(payload);
+    return user;
+  }
+
+  async findUser(token: TokenInterface): Promise<AuthDto> {
+    const userFromDb = await this.userRepository.findById(+token['id']);
+    if (userFromDb.nickname) throw new BadRequestException();
+
+    const existUser: AuthDto = new AuthDto(
+      userFromDb.id,
+      userFromDb.nickname,
+      token.secondAuthRequierd,
+      ROLETYPE_NONAME,
+    );
+    return existUser;
+  }
+}

--- a/src/test/test.service.ts
+++ b/src/test/test.service.ts
@@ -49,6 +49,18 @@ export class TestService {
     return user;
   }
 
+  async createNonameUser(): Promise<User> {
+    const index: number = this.users.length;
+    const user = await this.userRepository.save({
+      nickname: null,
+      email: index.toString() + '@mail.com',
+      statusMessage: index.toString(),
+      image: this.profileImages[0],
+    });
+    this.users.push(user);
+    return user;
+  }
+
   async giveTokenToUser(user: User) {
     const token = this.jwtService.sign({
       id: user.id,


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#59
+ PR Type: `feat`, `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
Noname 가드 구현 ,
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 가드 적용해서 유저 id, nickname 빼오는거 적용해서 간단화
  - 닉네임 있으면 BadRequest 
- Signup시 secondAuthRequired 업데이트 적용 
- auth/signup 테스트 코드 추가
## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->
- 직접 Req 에서 토큰 빼와서 확인 화지 않고 가드로 처리 함. 

